### PR TITLE
added new method PICC_IsCardPresent and an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ sudo make install
 ```
 
 ### Try an example
+Available examples:
+  * ReadUidMultiReader - Example program showing how to read data from more than one PICC to serial.
+  * ReadNUID - Example program showing how to read new NUID from a PICC to serial (only if a new card is present).
+  * IsCardPresent - Example program showing how to check if a card is present.
+
 1. Download this repo by running ```git clone https://github.com/CoolCyberBrain/RPi-MFRC522.git```
 2. Enter the folder by running ```cd RPi-MFRC522```
 3. Build the ReadNUID example by running the following command

--- a/examples/IsCardPresent/IsCardPresent.cpp
+++ b/examples/IsCardPresent/IsCardPresent.cpp
@@ -1,0 +1,50 @@
+#include "MFRC522.h"
+#include <string>
+#include <chrono>
+#include <thread>
+
+
+// The GPIO pin that's connected to the MFRC522's reset pin
+#define RST_PIN RPI_V2_GPIO_P1_15
+// The GPIO pin that's connected to the MFRC522's SDA pin,
+// sometimes labeled SS or CE or CS.
+// Doesn't have to be one of the CE pins on the pi
+#define SS_PIN RPI_V2_GPIO_P1_38
+
+/**
+ * Helper routine to dump a byte array as hex values.
+ */
+void printHex(uint8_t *buffer, size_t bufferSize) {
+  for (size_t i = 0; i < bufferSize; i++) {
+    printf(" %02X", buffer[i]);
+  }
+}
+
+int main() {
+    MFRC522 rfid = MFRC522(SS_PIN, RST_PIN);  // Instance of the class
+    rfid.PCD_Init();
+
+    bool card_present = false;
+
+    while (1) {
+        if (rfid.PICC_IsCardPresent()) {
+            if (!card_present) {
+                if (rfid.PICC_ReadCardSerial()) {
+                    printf("card present: ");
+                    printHex(rfid.uid.uidByte, rfid.uid.size);
+                    printf("\n");
+                    card_present = true;
+                }
+            }
+            rfid.PICC_HaltA();
+            rfid.PCD_StopCrypto1();
+        } else {
+            if (card_present) {
+                printf("card removed\n");
+                card_present = false;
+            }
+        }
+    }
+
+    return 0;
+}

--- a/src/MFRC522.cpp
+++ b/src/MFRC522.cpp
@@ -1918,3 +1918,23 @@ bool MFRC522::PICC_ReadCardSerial() {
 	MFRC522::StatusCode result = PICC_Select(&uid);
 	return (result == STATUS_OK);
 } // End 
+
+/**
+ * Returns true if a PICC responds to PICC_CMD_REQA.
+ * All cards are invited (-> cards in state IDLE _and_ HALT).
+ * 
+ * @return bool
+ */
+bool MFRC522::PICC_IsCardPresent() {
+	byte bufferATQA[2];
+	byte bufferSize = sizeof(bufferATQA);
+
+    // Reset baud rates
+	PCD_WriteRegister(TxModeReg, 0x00);
+	PCD_WriteRegister(RxModeReg, 0x00);
+	// Reset ModWidthReg
+	PCD_WriteRegister(ModWidthReg, 0x26);
+
+	MFRC522::StatusCode result = PICC_WakeupA(bufferATQA, &bufferSize); // check cards in state HALT/IDLE
+	return (result == STATUS_OK || result == STATUS_COLLISION);
+} 

--- a/src/MFRC522.h
+++ b/src/MFRC522.h
@@ -427,6 +427,7 @@ public:
 	/////////////////////////////////////////////////////////////////////////////////////
 	virtual bool PICC_IsNewCardPresent();
 	virtual bool PICC_ReadCardSerial();
+	virtual bool PICC_IsCardPresent();
 	
 protected:
 	byte _chipSelectPin;		// Arduino pin connected to MFRC522's SPI slave select input (Pin 24, NSS, active low)


### PR DESCRIPTION
PICC_IsNewCardPresent is sufficient for most use cases. But in some it is necessary to check if a card is (still) present - e.g. when using rfid-tags to control a juke box. -> i added the PICC_IsCardPresent method and an example.